### PR TITLE
Added linting (errors only)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,15 +9,22 @@ clone:
     tags: true
 
 pipeline:
+  lint:
+    image: endian/go:1.0.1
+    commands:
+      - make lint
+    when:
+      event: [pull_request]
+
   vendor:
-    image: kowalatech/go:1.0.12
+    image: endian/go:1.0.1
     commands:
       - dep ensure --vendor-only
     when:
       event: [pull_request]
 
   test:
-    image: kowalatech/go:1.0.12
+    image: endian/go:1.0.1
     commands:
       - make test
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,13 +9,6 @@ clone:
     tags: true
 
 pipeline:
-  lint:
-    image: endian/go:1.0.1
-    commands:
-      - make lint
-    when:
-      event: [pull_request]
-
   vendor:
     image: endian/go:1.0.1
     commands:
@@ -26,7 +19,7 @@ pipeline:
   test:
     image: endian/go:1.0.1
     commands:
-      - make test
+      - make lint test
     when:
       event: [pull_request]
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ test: dep godog
 	go test ./...
 	(cd cmd/ && godog ../features)
 
+.PHONY: lint
+lint: gometalinter
+	gometalinter.v2 --errors --vendor --exclude=vendor --config gometalinter.json ./...
+
 .PHONY: mock
 dir ?= .
 mock: export filename=$(shell echo $(name) | tr A-Z a-z)_mock.go
@@ -37,4 +41,14 @@ dep:
 ifndef DEP_BIN
 	@echo "Installing dep..."
 	@go get github.com/golang/dep/cmd/dep
+	@dep ensure --vendor-only
+endif
+
+.PHONY: gomentalinter
+GOMETALINTER_BIN := $(shell command -v gometalinter.v2 2> /dev/null)
+gometalinter:
+ifndef GOMETALINTER_BIN
+	@echo "Installing gometalinter..."
+	@go get gopkg.in/alecthomas/gometalinter.v2
+	@gometalinter.v2 --install
 endif

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,0 +1,20 @@
+{
+  "Vendor": true,
+  "Deadline": "2m",
+  "Sort": ["linter", "severity", "path", "line"],
+  "EnableGC": true,
+  "WarnUnmatchedDirective": true,
+  "Cyclo": 15,
+  "Enable": [
+    "deadcode",
+	"lll",
+    "gocyclo",
+    "gofmt",
+	"gosimple",
+    "misspell",
+    "unconvert",
+    "unused",
+    "vet"
+  ],
+  "LineLength": 100
+}

--- a/specstack.go
+++ b/specstack.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	// Thrown when a git repo is not initialised
 	ErrUninitialisedRepo = errors.New("Please initialise repository first before running")
 )
 
@@ -45,11 +46,9 @@ func (a *appController) Initialise() error {
 	}
 
 	var err error
-	if a.config, err = a.loadOrCreateConfig(); err != nil {
-		return err
-	}
+	a.config, err = a.loadOrCreateConfig()
 
-	return nil
+	return err
 }
 
 func (a *appController) loadOrCreateConfig() (*config.Config, error) {


### PR DESCRIPTION
Added gometalinter to the build process. This currently only checks for errors, because there quite a lot of warnings.

The CI now uses the dedicated [Endian Go Docker image](https://hub.docker.com/r/endian/go/).